### PR TITLE
Allow clients to specify thier own firebase configuration implementation

### DIFF
--- a/FirebaseCoreAdmin/Firebase/Database/FirebaseAdminDatabase.cs
+++ b/FirebaseCoreAdmin/Firebase/Database/FirebaseAdminDatabase.cs
@@ -10,9 +10,13 @@
     {
         private IFirebaseHttpClient _httpClient;
 
-        public FirebaseAdminDatabase(IFirebaseAdminAuth auth, IServiceAccountCredentials credentials)
+        public FirebaseAdminDatabase(IFirebaseAdminAuth auth, IServiceAccountCredentials credentials, IFirebaseConfiguration configuration)
         {
-            var firebaseConfiguration = new DefaultFirebaseConfiguration(GoogleServiceAccess.DatabaseOnly);
+            IFirebaseConfiguration firebaseConfiguration = new DefaultFirebaseConfiguration(GoogleServiceAccess.DatabaseOnly);
+            if (configuration != null)
+            {
+                firebaseConfiguration = configuration;
+            }
 
             var firebaseAuthority = new Uri($"https://{credentials.GetProjectId()}.{firebaseConfiguration.FirebaseHost}/", UriKind.Absolute);
             _httpClient = new FirebaseHttpClient(credentials, firebaseConfiguration, firebaseAuthority);

--- a/FirebaseCoreAdmin/Firebase/Storage/GoogleCloudStorage.cs
+++ b/FirebaseCoreAdmin/Firebase/Storage/GoogleCloudStorage.cs
@@ -12,6 +12,7 @@
     using FirebaseCoreAdmin.Firebase.Auth;
     using System.Threading.Tasks;
     using System.Net.Http;
+    using Configurations;
 
     public class GoogleCloudStorage : IGoogleStorage, IDisposable
     {
@@ -19,9 +20,14 @@
         private IServiceAccountCredentials _credentials;
         private IFirebaseConfiguration _firebaseConfiguration;
 
-        public GoogleCloudStorage(IFirebaseAdminAuth auth, IServiceAccountCredentials credentials)
+        public GoogleCloudStorage(IFirebaseAdminAuth auth, IServiceAccountCredentials credentials, IFirebaseConfiguration configuration)
         {
-            var firebaseConfiguration = new DefaultFirebaseConfiguration(GoogleServiceAccess.StorageOnly);
+            IFirebaseConfiguration firebaseConfiguration = new DefaultFirebaseConfiguration(GoogleServiceAccess.StorageOnly);
+            if (configuration != null)
+            {
+                firebaseConfiguration = configuration;
+            }
+
             var storageAuthority = new Uri($"{firebaseConfiguration.StorageBaseAuthority.TrimSlashes()}", UriKind.Absolute);
 
             _httpClient = new FirebaseHttpClient(credentials, firebaseConfiguration, storageAuthority);

--- a/FirebaseCoreAdmin/FirebaseAdmin.cs
+++ b/FirebaseCoreAdmin/FirebaseAdmin.cs
@@ -5,6 +5,7 @@
     using FirebaseCoreAdmin.Firebase.Auth;
     using FirebaseCoreAdmin.Firebase.Database;
     using FirebaseCoreAdmin.Firebase.Storage;
+    using Configurations;
 
     public class FirebaseAdmin : IFirebaseAdmin, IDisposable
     {
@@ -38,6 +39,11 @@
             Initialize(credentials, access);
         }
 
+        public FirebaseAdmin(IServiceAccountCredentials credentials, GoogleServiceAccess access, IFirebaseConfiguration configuration)
+        {
+            Initialize(credentials, access, configuration);
+        }
+
         #endregion
 
         #region IDisposable Methods
@@ -65,17 +71,17 @@
 
         #region Private Helpers
 
-        private void Initialize(IServiceAccountCredentials credentials, GoogleServiceAccess access)
+        private void Initialize(IServiceAccountCredentials credentials, GoogleServiceAccess access, IFirebaseConfiguration configuration = null)
         {
             _requestedAccess = access;
             _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
             _auth = new FirebaseAdminAuth();
 
             if (GoogleServiceAccess.DatabaseOnly == (_requestedAccess & GoogleServiceAccess.DatabaseOnly))
-                _database = new FirebaseAdminDatabase(_auth, _credentials);
+                _database = new FirebaseAdminDatabase(_auth, _credentials, configuration);
 
             if (GoogleServiceAccess.StorageOnly == (_requestedAccess & GoogleServiceAccess.StorageOnly))
-                _storage = new GoogleCloudStorage(_auth, _credentials);
+                _storage = new GoogleCloudStorage(_auth, _credentials, configuration);
         }
 
         #endregion


### PR DESCRIPTION
Sometimes clients need to override some config values like `CustomTokenTTL`. Clients can now inherit from `DefaultFirebaseConfiguration` and override values as they require.